### PR TITLE
fix parsera dla słów które nie znajdują się w słowniku (np Vesuvio)

### DIFF
--- a/src/main/java/pl/poznan/put/cs/si/puttalky/Parser.java
+++ b/src/main/java/pl/poznan/put/cs/si/puttalky/Parser.java
@@ -62,10 +62,11 @@ public class Parser {
 		
 		for (String slowo : slowa){ 
 			String token = new String("");
-			if (stem(s, slowo).length>1){
+			if (stem(s, slowo).length>1)
 				token = stem(s, slowo)[0];
-				tokeny.add(token);
-			} 
+			else
+				token = slowo.toLowerCase();
+			tokeny.add(token);
 		}
 		
 	    return tokeny.toArray(new String[tokeny.size()]);


### PR DESCRIPTION
Niektóre zadania wymagają podania nazwy pizzy która nie znajduje się w słowniku. Ten PR rozwiązuje problem pomijania tych słów.